### PR TITLE
Corrected #6: AWS CLI Install Now Automatic

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -8,8 +8,8 @@ tasks:
     before: |
       cd /workspace
       curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-      unzip awscliv2.zip
-      sudo ./aws/install
+      unzip -u awscliv2.zip
+      sudo ./aws/install --update
       cd $THEIA_WORKSPACE_ROOT
 vscode:
   extensions:


### PR DESCRIPTION
Added modifiers to the AWS CLI install to prevent needing user intervention

Referenced from [AWS Documentation](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)